### PR TITLE
Integrate NextAuth.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# MVP
+# BrandSkept MVP
+
+This repository contains early planning documents and a minimal frontend prototype for the BrandSkept MVP. The frontend is built with **Next.js** and uses **NextAuth.js** to handle authentication against backend APIs.
+
+## Getting Started
+
+1. Copy `.env.example` to `.env.local` and adjust the URLs for your environment.
+2. Install dependencies and start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app will run on `http://localhost:3000`.
+
+## Authentication Flow
+
+`NextAuth.js` is configured to use a **Credentials** provider. When a user signs in, their credentials are sent to the backend API (`/login`) and the returned user object is stored in a JWT session. Registration posts to the `/register` endpoint on the same API.
+
+See `frontend/pages/api/auth/[...nextauth].ts` for the full configuration.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+NEXTAUTH_URL=http://localhost:3000
+NEXT_PUBLIC_API_URL=http://localhost:4000/api

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "brandskept-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "next-auth": "4.22.1"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,10 @@
+import { SessionProvider } from 'next-auth/react';
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  );
+}

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,54 @@
+import NextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+export const authOptions = {
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) {
+          return null;
+        }
+
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: credentials.email,
+            password: credentials.password
+          })
+        });
+
+        if (!res.ok) {
+          return null;
+        }
+
+        const user = await res.json();
+        return user;
+      }
+    })
+  ],
+  session: {
+    strategy: 'jwt'
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = user.id;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token && session.user) {
+        session.user.id = token.id as string;
+      }
+      return session;
+    }
+  }
+};
+
+export default NextAuth(authOptions);

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,25 @@
+import { signIn, signOut, useSession } from 'next-auth/react';
+import Link from 'next/link';
+
+export default function Home() {
+  const { data: session } = useSession();
+
+  if (!session) {
+    return (
+      <div>
+        <h1>Welcome to BrandSkept</h1>
+        <button onClick={() => signIn()}>Sign In</button>
+        <p>
+          New here? <Link href="/register">Register</Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1>Hello, {session.user?.name}</h1>
+      <button onClick={() => signOut()}>Sign Out</button>
+    </div>
+  );
+}

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+export default function Register() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, name })
+    });
+
+    if (res.ok) {
+      setMessage('Registration successful. You can sign in now.');
+    } else {
+      const data = await res.json();
+      setMessage(data.message || 'Registration failed');
+    }
+  }
+
+  return (
+    <div>
+      <h1>Create an account</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Register</button>
+      </form>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up minimal Next.js frontend with NextAuth.js
- provide credential-based auth provider tied to backend API
- add simple registration form and homepage
- document setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f1e76ab1c8332935ea84ccbf41190