### PR TITLE
Add demo poll API and frontend pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # MVP
+
+This repository contains a very small prototype for the BrandSkept platform. A minimal Express API and a few Next.js style pages demonstrate how brands can create polls/A/B tests and how consumers can participate and track points.
+
+## Running
+
+The project assumes `node` is available. Dependencies such as `express` or `next` are not bundled. In a real environment you would run `npm install` before starting the server.
+
+```bash
+npm start
+```
+
+The API will run on port 3000 by default.
+
+## Testing
+
+No real automated tests are included. Running:
+
+```bash
+npm test
+```
+
+will attempt to start the API in test mode.

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+const polls = [];
+const users = {}; // userId -> {points: Number}
+let nextId = 1;
+
+// Create a new poll (A/B test)
+app.post('/api/admin/polls', (req, res) => {
+  const { question, optionA, optionB } = req.body;
+  if (!question || !optionA || !optionB) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const poll = {
+    id: nextId++,
+    question,
+    options: [optionA, optionB],
+    votes: { A: 0, B: 0 },
+  };
+  polls.push(poll);
+  res.json(poll);
+});
+
+// List all polls
+app.get('/api/polls', (req, res) => {
+  res.json(polls);
+});
+
+// Get a single poll
+app.get('/api/polls/:id', (req, res) => {
+  const poll = polls.find(p => p.id === Number(req.params.id));
+  if (!poll) return res.status(404).json({ error: 'Poll not found' });
+  res.json(poll);
+});
+
+// Vote on a poll
+app.post('/api/polls/:id/vote', (req, res) => {
+  const poll = polls.find(p => p.id === Number(req.params.id));
+  if (!poll) return res.status(404).json({ error: 'Poll not found' });
+  const { userId, option } = req.body;
+  if (!userId || !['A', 'B'].includes(option)) {
+    return res.status(400).json({ error: 'Invalid vote' });
+  }
+  poll.votes[option]++;
+  const user = users[userId] || { points: 0 };
+  user.points += 10;
+  users[userId] = user;
+  res.json({ success: true, points: user.points });
+});
+
+// Get user points and simple rewards
+app.get('/api/users/:userId', (req, res) => {
+  const user = users[req.params.userId] || { points: 0 };
+  const rewards = user.points >= 100 ? ['Gold reward'] : [];
+  res.json({ points: user.points, rewards });
+});
+
+if (!module.parent) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => console.log(`Server running on port ${port}`));
+}
+
+module.exports = app;

--- a/frontend/pages/admin/create-poll.js
+++ b/frontend/pages/admin/create-poll.js
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+export default function CreatePoll() {
+  const [question, setQuestion] = useState('');
+  const [optionA, setOptionA] = useState('');
+  const [optionB, setOptionB] = useState('');
+  const [createdId, setCreatedId] = useState(null);
+
+  const submit = async e => {
+    e.preventDefault();
+    const res = await fetch('/api/admin/polls', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question, optionA, optionB })
+    });
+    const data = await res.json();
+    if (data.id) setCreatedId(data.id);
+  };
+
+  return (
+    <div>
+      <h1>Create Poll / A-B Test</h1>
+      <form onSubmit={submit}>
+        <input value={question} onChange={e => setQuestion(e.target.value)} placeholder="Question" />
+        <input value={optionA} onChange={e => setOptionA(e.target.value)} placeholder="Option A" />
+        <input value={optionB} onChange={e => setOptionB(e.target.value)} placeholder="Option B" />
+        <button type="submit">Create</button>
+      </form>
+      {createdId && <p>Created poll #{createdId}</p>}
+    </div>
+  );
+}

--- a/frontend/pages/campaign/[id].js
+++ b/frontend/pages/campaign/[id].js
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function Campaign() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [poll, setPoll] = useState(null);
+  const [option, setOption] = useState('A');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/polls/${id}`)
+      .then(res => res.json())
+      .then(setPoll)
+      .catch(() => {});
+  }, [id]);
+
+  const vote = async () => {
+    const res = await fetch(`/api/polls/${id}/vote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: 'demo-user', option })
+    });
+    const data = await res.json();
+    setMessage(`Thank you! You have ${data.points} points.`);
+  };
+
+  if (!poll) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1>{poll.question}</h1>
+      <label>
+        <input type="radio" checked={option==='A'} onChange={()=>setOption('A')} /> {poll.options[0]}
+      </label>
+      <label>
+        <input type="radio" checked={option==='B'} onChange={()=>setOption('B')} /> {poll.options[1]}
+      </label>
+      <button onClick={vote}>Vote</button>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export default function Home() {
+  const [polls, setPolls] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/polls')
+      .then(res => res.json())
+      .then(setPolls)
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div>
+      <h1>Active Campaigns</h1>
+      <ul>
+        {polls.map(p => (
+          <li key={p.id}>
+            <a href={`/campaign/${p.id}`}>{p.question}</a>
+          </li>
+        ))}
+      </ul>
+      <a href="/admin/create-poll">Create a Poll</a>
+    </div>
+  );
+}

--- a/frontend/pages/user/[id]/points.js
+++ b/frontend/pages/user/[id]/points.js
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function Points() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/users/${id}`)
+      .then(res => res.json())
+      .then(setData)
+      .catch(() => {});
+  }, [id]);
+
+  if (!data) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1>User Points</h1>
+      <p>Points: {data.points}</p>
+      {data.rewards && data.rewards.length > 0 && (
+        <ul>
+          {data.rewards.map(r => (<li key={r}>{r}</li>))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "brandskept-mvp",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "node api/server.js",
+    "test": "node api/server.js --test"
+  }
+}


### PR DESCRIPTION
## Summary
- implement Express server with simple poll endpoints
- add Next.js-style pages for brand admins and consumers
- document how to run the prototype
- define npm scripts

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684f295543f883328961c34fd3e33fc8