### PR TITLE
Clean next-env references

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,9 +1,5 @@
 /// <reference types="next" />
- codex/initialize-next.js-project-with-tailwind-css-and-shadcn/ui
-
 /// <reference types="next/types/global" />
- main
 /// <reference types="next/image-types/global" />
-
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## Summary
- remove stray lines from the frontend `next-env.d.ts`

## Testing
- `npm test` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68570cff0ca883329e83e23c40bea166