### PR TITLE
Fix invalid package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "scripts": {
     "start": "node api/server.js",
- codex/create-api-routes-for-polls-and-campaigns
-    "test": "node api/server.js --test"
-
     "test": "jest"
   },
   "devDependencies": {
@@ -14,6 +11,5 @@
   },
   "dependencies": {
     "express": "^5.1.0"
- main
   }
 }


### PR DESCRIPTION
## Summary
- fix malformed root package.json by removing stray text and duplicate entries

## Testing
- `npm test` *(fails: Cannot parse frontend/package.json as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68583aa32f408332bb5183919c23f519