### PR TITLE
Implement brand authentication module

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -18,3 +18,13 @@ This directory contains a starter Express server written in TypeScript and confi
    ```
 
 The server exposes a root endpoint (`/`) returning a simple JSON message and a `/users` endpoint that queries the database using Prisma.
+
+## Brand Authentication Module
+
+`src/brand-auth/` contains a modular authentication system for partner brands. It supports:
+
+- **OTP**: email-based one-time codes with a 5 minute expiration.
+- **OAuth**: Google, Discord and GitHub examples via Passport.js.
+- **SSO**: pluggable strategy outline for SAML/OIDC providers.
+
+Routes are mounted under `/brand-auth`. Feature flags and provider credentials are configured in `src/brand-auth/config.ts`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,13 @@
   "type": "module",
   "dependencies": {
     "express": "^4.18.2",
-    "@prisma/client": "^5.15.0"
+    "@prisma/client": "^5.15.0",
+    "express-session": "^1.17.3",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
+    "passport-discord": "^0.1.4",
+    "passport-github2": "^0.1.12",
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "typescript": "^5.4.2",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,3 +16,21 @@ model User {
   name      String?
   createdAt DateTime @default(now())
 }
+
+model Brand {
+  id        Int             @id @default(autoincrement())
+  email     String          @unique
+  name      String?
+  createdAt DateTime        @default(now())
+  accounts  BrandAccount[]
+}
+
+model BrandAccount {
+  id                Int      @id @default(autoincrement())
+  provider          String
+  providerAccountId String
+  type              String
+  brand             Brand    @relation(fields: [brandId], references: [id])
+  brandId           Int
+  createdAt         DateTime @default(now())
+}

--- a/backend/src/brand-auth/config.ts
+++ b/backend/src/brand-auth/config.ts
@@ -1,0 +1,31 @@
+export const brandAuthConfig = {
+  strategies: {
+    otp: true,
+    oauth: true,
+    sso: true,
+  },
+  jwtSecret: process.env.BRAND_JWT_SECRET || 'change_me',
+  otpExpireMinutes: 5,
+  oauthProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+    },
+    microsoft: {
+      clientId: process.env.MICROSOFT_CLIENT_ID || '',
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET || '',
+    },
+    apple: {
+      clientId: process.env.APPLE_CLIENT_ID || '',
+      clientSecret: process.env.APPLE_CLIENT_SECRET || '',
+    },
+    discord: {
+      clientId: process.env.DISCORD_CLIENT_ID || '',
+      clientSecret: process.env.DISCORD_CLIENT_SECRET || '',
+    },
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID || '',
+      clientSecret: process.env.GITHUB_CLIENT_SECRET || '',
+    },
+  },
+};

--- a/backend/src/brand-auth/index.ts
+++ b/backend/src/brand-auth/index.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { otpRouter } from './otp';
+import { oauthRouter } from './oauth';
+import { ssoRouter } from './sso';
+import { brandAuthConfig } from './config';
+
+export const brandAuthRouter = Router();
+
+// Mount OTP endpoints
+if (brandAuthConfig.strategies.otp) {
+  brandAuthRouter.use('/otp', otpRouter);
+}
+
+// Mount OAuth endpoints
+if (brandAuthConfig.strategies.oauth) {
+  brandAuthRouter.use('/oauth', oauthRouter);
+}
+
+// Mount SSO endpoints (outline only)
+if (brandAuthConfig.strategies.sso) {
+  brandAuthRouter.use('/sso', ssoRouter);
+}

--- a/backend/src/brand-auth/oauth.ts
+++ b/backend/src/brand-auth/oauth.ts
@@ -1,0 +1,117 @@
+import { Router } from 'express';
+import passport from 'passport';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
+import { Strategy as DiscordStrategy } from 'passport-discord';
+import { Strategy as GitHubStrategy } from 'passport-github2';
+import { PrismaClient } from '@prisma/client';
+import { brandAuthConfig } from './config';
+import { signToken } from './session';
+
+const prisma = new PrismaClient();
+export const oauthRouter = Router();
+
+passport.serializeUser((user: any, done) => done(null, user));
+passport.deserializeUser((obj: any, done) => done(null, obj));
+
+function ensureProviderAccount(provider: string, id: string, email: string) {
+  return prisma.$transaction(async () => {
+    let brand = await prisma.brand.findUnique({ where: { email } });
+    if (!brand) {
+      brand = await prisma.brand.create({ data: { email } });
+    }
+    const account = await prisma.brandAccount.findFirst({
+      where: { provider, providerAccountId: id, brandId: brand.id },
+    });
+    if (!account) {
+      await prisma.brandAccount.create({
+        data: { provider, providerAccountId: id, type: 'oauth', brandId: brand.id },
+      });
+    }
+    return brand;
+  });
+}
+
+if (brandAuthConfig.strategies.oauth) {
+  const { google, discord, github } = brandAuthConfig.oauthProviders;
+  if (google.clientId) {
+    passport.use(
+      new GoogleStrategy(
+        {
+          clientID: google.clientId,
+          clientSecret: google.clientSecret,
+          callbackURL: '/brand-auth/oauth/google/callback',
+        },
+        async (_access, _refresh, profile, done) => {
+          const email = profile.emails?.[0].value;
+          if (!email) return done(null, false);
+          const brand = await ensureProviderAccount('google', profile.id, email);
+          done(null, brand);
+        },
+      ),
+    );
+    oauthRouter.get('/google', passport.authenticate('google', { scope: ['email'] }));
+    oauthRouter.get(
+      '/google/callback',
+      passport.authenticate('google', { session: false }),
+      (req, res) => {
+        const brand = req.user as any;
+        const token = signToken({ brandId: brand.id });
+        res.json({ token, brand });
+      },
+    );
+  }
+  if (discord.clientId) {
+    passport.use(
+      new DiscordStrategy(
+        {
+          clientID: discord.clientId,
+          clientSecret: discord.clientSecret,
+          callbackURL: '/brand-auth/oauth/discord/callback',
+          scope: ['identify', 'email'],
+        },
+        async (_access, _refresh, profile, done) => {
+          const email = profile.email;
+          if (!email) return done(null, false);
+          const brand = await ensureProviderAccount('discord', profile.id, email);
+          done(null, brand);
+        },
+      ),
+    );
+    oauthRouter.get('/discord', passport.authenticate('discord'));
+    oauthRouter.get(
+      '/discord/callback',
+      passport.authenticate('discord', { session: false }),
+      (req, res) => {
+        const brand = req.user as any;
+        const token = signToken({ brandId: brand.id });
+        res.json({ token, brand });
+      },
+    );
+  }
+  if (github.clientId) {
+    passport.use(
+      new GitHubStrategy(
+        {
+          clientID: github.clientId,
+          clientSecret: github.clientSecret,
+          callbackURL: '/brand-auth/oauth/github/callback',
+        },
+        async (_access, _refresh, profile, done) => {
+          const email = profile.emails?.[0].value || profile.username;
+          const brand = await ensureProviderAccount('github', profile.id, email);
+          done(null, brand);
+        },
+      ),
+    );
+    oauthRouter.get('/github', passport.authenticate('github', { scope: ['user:email'] }));
+    oauthRouter.get(
+      '/github/callback',
+      passport.authenticate('github', { session: false }),
+      (req, res) => {
+        const brand = req.user as any;
+        const token = signToken({ brandId: brand.id });
+        res.json({ token, brand });
+      },
+    );
+  }
+}

--- a/backend/src/brand-auth/otp.ts
+++ b/backend/src/brand-auth/otp.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { brandAuthConfig } from './config';
+import { signToken } from './session';
+
+const prisma = new PrismaClient();
+const otpStore = new Map<string, { code: string; expires: number }>();
+
+export const otpRouter = Router();
+
+otpRouter.post('/send', async (req, res) => {
+  if (!brandAuthConfig.strategies.otp) return res.status(404).end();
+  const { email } = req.body as { email?: string };
+  if (!email) return res.status(400).json({ error: 'Email required' });
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+  const expires = Date.now() + brandAuthConfig.otpExpireMinutes * 60 * 1000;
+  otpStore.set(email, { code, expires });
+  // In real implementation send email here
+  console.log(`OTP for ${email}: ${code}`);
+  res.json({ success: true });
+});
+
+otpRouter.post('/verify', async (req, res) => {
+  if (!brandAuthConfig.strategies.otp) return res.status(404).end();
+  const { email, code } = req.body as { email?: string; code?: string };
+  if (!email || !code) return res.status(400).json({ error: 'Missing fields' });
+  const entry = otpStore.get(email);
+  if (!entry || entry.code !== code || Date.now() > entry.expires) {
+    return res.status(400).json({ error: 'Invalid or expired code' });
+  }
+  otpStore.delete(email);
+  let brand = await prisma.brand.findUnique({ where: { email } });
+  if (!brand) {
+    brand = await prisma.brand.create({ data: { email } });
+  }
+  const token = signToken({ brandId: brand.id });
+  res.json({ token, brand });
+});

--- a/backend/src/brand-auth/session.ts
+++ b/backend/src/brand-auth/session.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { brandAuthConfig } from './config';
+
+export function signToken(payload: object): string {
+  return jwt.sign(payload, brandAuthConfig.jwtSecret, { expiresIn: '1h' });
+}
+
+export function verifyToken(req: Request, res: Response, next: NextFunction) {
+  const header = req.headers.authorization;
+  if (!header) return res.status(401).json({ error: 'Missing Authorization header' });
+  const token = header.replace(/^Bearer\s+/i, '');
+  try {
+    (req as any).auth = jwt.verify(token, brandAuthConfig.jwtSecret);
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}

--- a/backend/src/brand-auth/sso.ts
+++ b/backend/src/brand-auth/sso.ts
@@ -1,0 +1,53 @@
+/**
+ * Outline for integrating enterprise SSO using SAML or OIDC.
+ * This file demonstrates how a pluggable strategy could be added
+ * without impacting OTP or OAuth routes.
+ */
+
+import { Router } from 'express';
+import passport from 'passport';
+import { brandAuthConfig } from './config';
+import { signToken } from './session';
+import { PrismaClient } from '@prisma/client';
+
+export const ssoRouter = Router();
+const prisma = new PrismaClient();
+
+// Example using passport-saml. In a real project you would install
+// `passport-saml` and configure the strategy with metadata from the IdP.
+// Metadata discovery could be implemented via well-known URLs or admin input.
+
+// import { Strategy as SamlStrategy } from 'passport-saml';
+// if (brandAuthConfig.strategies.sso) {
+//   passport.use(new SamlStrategy({
+//     path: '/brand-auth/sso/saml/callback',
+//     entryPoint: 'https://idp.example.com/saml/login',
+//     issuer: 'brandskept',
+//     cert: fs.readFileSync('idp_cert.pem', 'utf8'),
+//   }, async (profile, done) => {
+//     const email = profile.email;
+//     let brand = await prisma.brand.findUnique({ where: { email } });
+//     if (!brand) brand = await prisma.brand.create({ data: { email } });
+//     done(null, brand);
+//   }));
+//   ssoRouter.post('/saml/callback', passport.authenticate('saml', { session: false }), (req, res) => {
+//     const brand = req.user as any;
+//     const token = signToken({ brandId: brand.id });
+//     res.json({ token, brand });
+//   });
+// }
+
+/**
+ * Example metadata configuration for an external IdP
+ * {
+ *   "entityId": "https://idp.example.com/metadata",
+ *   "ssoLoginUrl": "https://idp.example.com/saml/login",
+ *   "certificate": "-----BEGIN CERTIFICATE-----..."
+ * }
+ */
+
+export function discoverIdpMetadata(url: string) {
+  // Placeholder for fetching IdP metadata (XML or JSON)
+  // In production you would download the metadata and parse certificates,
+  // endpoints, and bindings.
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,11 +1,23 @@
 import express from 'express';
 import { PrismaClient } from '@prisma/client';
+import passport from 'passport';
+import session from 'express-session';
+import { brandAuthRouter } from './brand-auth';
 
 const prisma = new PrismaClient();
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(express.json());
+app.use(
+  session({
+    secret: process.env.BRAND_JWT_SECRET || 'change_me',
+    resave: false,
+    saveUninitialized: false,
+  }),
+);
+app.use(passport.initialize());
+app.use(passport.session());
 
 app.get('/', (_req, res) => {
   res.json({ message: 'API is running' });
@@ -16,6 +28,9 @@ app.get('/users', async (_req, res) => {
   const users = await prisma.user.findMany();
   res.json(users);
 });
+
+// Routes for brand authentication
+app.use('/brand-auth', brandAuthRouter);
 
 app.listen(port, () => {
   console.log(`Server listening on port ${port}`);


### PR DESCRIPTION
## Summary
- scaffold brand-auth folder
- add OTP email code routes
- configure OAuth providers
- outline SAML/OIDC SSO strategy
- mount brand-auth router in backend
- document auth module in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584291bb9483328addcf27edcb99ae