### PR TITLE
Add SurveyTable component

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,9 @@
+import { SurveyTable } from '../components';
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-bold">Welcome to the Next.js app!</h1>
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <SurveyTable />
     </main>
   );
 }

--- a/frontend/components/SurveyTable.tsx
+++ b/frontend/components/SurveyTable.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+export type Survey = {
+  id: number;
+  title: string;
+  responses: number;
+  status: string;
+  modified: string;
+  lastResponse: string;
+};
+
+const sampleSurveys: Survey[] = [
+  {
+    id: 1,
+    title: 'Customer Satisfaction',
+    responses: 120,
+    status: 'active',
+    modified: '2024-05-01',
+    lastResponse: '2024-05-07',
+  },
+  {
+    id: 2,
+    title: 'Market Research',
+    responses: 80,
+    status: 'closed',
+    modified: '2024-04-25',
+    lastResponse: '2024-04-28',
+  },
+  {
+    id: 3,
+    title: 'Product Feedback',
+    responses: 45,
+    status: 'active',
+    modified: '2024-05-05',
+    lastResponse: '2024-05-06',
+  },
+  {
+    id: 4,
+    title: 'Employee Engagement',
+    responses: 200,
+    status: 'closed',
+    modified: '2024-04-10',
+    lastResponse: '2024-04-17',
+  },
+  {
+    id: 5,
+    title: 'Website Usability',
+    responses: 60,
+    status: 'active',
+    modified: '2024-05-03',
+    lastResponse: '2024-05-07',
+  },
+];
+
+export function useSurveys() {
+  const [surveys] = React.useState<Survey[]>(sampleSurveys);
+  return surveys;
+}
+
+export default function SurveyTable() {
+  const surveys = useSurveys();
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-300">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Title</th>
+            <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Responses</th>
+            <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Status</th>
+            <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Modified</th>
+            <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Last Response</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {surveys.map((s) => (
+            <tr key={s.id} className="odd:bg-white even:bg-gray-50 hover:bg-gray-100">
+              <td className="px-4 py-2 whitespace-nowrap">{s.title}</td>
+              <td className="px-4 py-2 whitespace-nowrap">{s.responses}</td>
+              <td className="px-4 py-2 whitespace-nowrap">{s.status}</td>
+              <td className="px-4 py-2 whitespace-nowrap">{s.modified}</td>
+              <td className="px-4 py-2 whitespace-nowrap">{s.lastResponse}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,0 +1,2 @@
+export { default as SurveyTable } from './SurveyTable';
+export { useSurveys } from './SurveyTable';


### PR DESCRIPTION
## Summary
- create SurveyTable component with mock data and Tailwind table styling
- export new component via `components` index
- showcase SurveyTable on the home page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869760b62708332a61f0b48dd462449