### PR TITLE
Add SurveyTable with loading and empty states

### DIFF
--- a/frontend/components/SurveyTable.tsx
+++ b/frontend/components/SurveyTable.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface Survey {
+  id: number;
+  question: string;
+}
+
+export default function SurveyTable() {
+  const [surveys, setSurveys] = useState<Survey[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/polls')
+      .then((res) => res.json())
+      .then((data) => setSurveys(data))
+      .catch(() => setSurveys([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-8 rounded bg-gray-200 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (surveys.length === 0) {
+    return (
+      <div className="py-8 text-center">
+        <p className="mb-4 text-gray-600">No surveys yet.</p>
+        <Link href="/admin/create-poll" className="font-medium text-blue-600 underline">
+          + Create Survey
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <table className="min-w-full border text-left">
+      <thead>
+        <tr>
+          <th className="border px-4 py-2">Question</th>
+        </tr>
+      </thead>
+      <tbody>
+        {surveys.map((s) => (
+          <tr key={s.id}>
+            <td className="border px-4 py-2">
+              <Link href={`/campaign/${s.id}`} className="text-blue-600 underline">
+                {s.question}
+              </Link>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,6 @@
 import { signIn, signOut, useSession } from 'next-auth/react';
 import Link from 'next/link';
+import SurveyTable from '../components/SurveyTable';
 
 export default function Home() {
   const { data: session } = useSession();
@@ -17,9 +18,12 @@ export default function Home() {
   }
 
   return (
-    <div>
-      <h1>Hello, {session.user?.name}</h1>
-      <button onClick={() => signOut()}>Sign Out</button>
+    <div className="space-y-4">
+      <div>
+        <h1>Hello, {session.user?.name}</h1>
+        <button onClick={() => signOut()}>Sign Out</button>
+      </div>
+      <SurveyTable />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `SurveyTable` component
- show loading skeleton while surveys load
- display an empty-state with '+ Create Survey' when no surveys exist
- render `SurveyTable` on the home page when user is logged in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697646f4b48332b98959636bf96d08