### PR TITLE
Remove leftover branch name from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
- codex/create-api-routes-for-polls-and-campaigns
 # MVP
 
 This repository contains a very small prototype for the BrandSkept platform. A minimal Express API and a few Next.js style pages demonstrate how brands can create polls/A/B tests and how consumers can participate and track points.


### PR DESCRIPTION
## Summary
- remove branch name heading from README

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a00f30a5c83329d8401157e21e98c