### PR TITLE
Add CreateSurveyModal component

### DIFF
--- a/frontend/components/App.tsx
+++ b/frontend/components/App.tsx
@@ -1,24 +1,42 @@
-import React from 'react';
+'use client';
+import React, { useState } from 'react';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import SearchBar from './SearchBar';
 import ViewToggle from './ViewToggle';
 import SurveyTable from './SurveyTable';
+import CreateSurveyModal from './CreateSurveyModal';
 
 export default function App() {
+  const [modalOpen, setModalOpen] = useState(false);
+
   return (
     <div className="grid min-h-screen grid-cols-[250px_1fr] grid-rows-[auto_1fr]">
       <div className="row-span-2 border-r">
         <Sidebar />
       </div>
       <Header />
-      <main className="p-4 overflow-auto">
-        <div className="flex items-center justify-between mb-4">
+      <main className="overflow-auto p-4">
+        <div className="mb-4 flex items-center justify-between gap-2">
           <SearchBar />
           <ViewToggle />
+          <button
+            className="rounded bg-blue-600 px-3 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onClick={() => setModalOpen(true)}
+          >
+            + Create Survey
+          </button>
         </div>
         <SurveyTable />
       </main>
+      <CreateSurveyModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSelect={(mode) => {
+          console.log('create mode:', mode);
+          setModalOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/components/CreateSurveyModal.tsx
+++ b/frontend/components/CreateSurveyModal.tsx
@@ -1,0 +1,133 @@
+'use client';
+import React, { useEffect, useRef } from 'react';
+
+export interface CreateSurveyModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (mode: 'scratch' | 'template') => void;
+}
+
+function useKeyPress(key: string, handler: () => void) {
+  useEffect(() => {
+    function listener(e: KeyboardEvent) {
+      if (e.key === key) {
+        handler();
+      }
+    }
+    window.addEventListener('keydown', listener);
+    return () => window.removeEventListener('keydown', listener);
+  }, [key, handler]);
+}
+
+export default function CreateSurveyModal({ isOpen, onClose, onSelect }: CreateSurveyModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useKeyPress('Escape', () => {
+    if (isOpen) onClose();
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable?.[0];
+    first?.focus();
+
+    function trap(e: KeyboardEvent) {
+      if (e.key !== 'Tab' || !focusable || focusable.length === 0) return;
+      const firstEl = focusable[0];
+      const lastEl = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        }
+      } else {
+        if (document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
+        }
+      }
+    }
+    document.addEventListener('keydown', trap);
+    return () => document.removeEventListener('keydown', trap);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      onClick={handleBackdropClick}
+    >
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+      >
+        <button
+          aria-label="Close"
+          className="absolute right-4 top-4 text-2xl leading-none text-gray-500 hover:text-gray-700 focus:outline-none"
+          onClick={onClose}
+        >
+          &times;
+        </button>
+        <h2 className="mb-6 text-center text-lg font-semibold">
+          How would you like to create your survey?
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <button
+            className="flex flex-col items-center rounded-2xl bg-gray-50 p-4 shadow hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onClick={() => onSelect('scratch')}
+          >
+            <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-600">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="2"
+                stroke="currentColor"
+                className="h-6 w-6"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+              </svg>
+            </div>
+            <span className="font-medium">Create from scratch</span>
+            <span className="text-sm text-gray-500 text-center">
+              Jump right in and build something beautiful
+            </span>
+          </button>
+          <button
+            className="flex flex-col items-center rounded-2xl bg-gray-50 p-4 shadow hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onClick={() => onSelect('template')}
+          >
+            <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-green-100 text-green-600">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="2"
+                stroke="currentColor"
+                className="h-6 w-6"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h16M4 14h8m-8 4h8" />
+              </svg>
+            </div>
+            <span className="font-medium">Create from template</span>
+            <span className="text-sm text-gray-500 text-center">
+              Pick a premade template and customize it
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,1 +1,2 @@
 export { default as SurveyTable } from './SurveyTable';
+export { default as CreateSurveyModal } from './CreateSurveyModal';


### PR DESCRIPTION
## Summary
- add CreateSurveyModal component with ESC handling and focus trap
- export new component
- show usage in App with a button to open the modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_686a2a02d2d48332a5a103e55617d266