### PR TITLE
Add DesignPage layout component

### DIFF
--- a/frontend/components/DesignPage.tsx
+++ b/frontend/components/DesignPage.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useState } from 'react';
+import DesignHeader from './DesignHeader';
+import BuilderSidebar from './BuilderSidebar';
+import QuestionConfig from './QuestionConfig';
+import OptionSetsEditor from './OptionSetsEditor';
+import QuestionTabs from './QuestionTabs';
+import PreviewPanel from './PreviewPanel';
+
+export default function DesignPage() {
+  const [previewView, setPreviewView] = useState<'preview' | 'logic'>('preview');
+
+  return (
+    <div className="grid min-h-screen grid-rows-[auto_1fr] bg-gray-50">
+      <DesignHeader surveyTitle="Untitled Survey" />
+      <div className="flex flex-1 overflow-hidden">
+        <div className="hidden md:block flex-shrink-0">
+          <BuilderSidebar />
+        </div>
+        <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+          <QuestionConfig />
+          <QuestionTabs />
+          <OptionSetsEditor />
+        </div>
+        <div className="w-80 flex-shrink-0 border-l bg-white p-4 overflow-y-auto hidden sm:block">
+          <PreviewPanel view={previewView} onTabChange={setPreviewView} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -4,3 +4,4 @@ export { default as OptionSetsEditor } from './OptionSetsEditor';
 export { default as QuestionConfig } from './QuestionConfig';
 export { default as QuestionTabs } from './QuestionTabs';
 export { default as PreviewPanel } from './PreviewPanel';
+export { default as DesignPage } from './DesignPage';


### PR DESCRIPTION
## Summary
- create `DesignPage` component to lay out design builder
- export `DesignPage` from components index

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in `frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a30631e648332865f8fdc74c3e94a